### PR TITLE
webpack require animate.js fail

### DIFF
--- a/build/iSlider.animate.js
+++ b/build/iSlider.animate.js
@@ -9,7 +9,7 @@
 (function (global, factory) {
     /* CommonJS */
     if (typeof require === 'function' && typeof module === 'object' && module && typeof exports === 'object' && exports)
-        factory(require('iSlider'));
+        factory(require('islider.js'));
     /* AMD */
     else if (typeof define === 'function' && define['amd'])
         define(['iSlider'], function (iSlider) {


### PR DESCRIPTION
use webpack require animate.js fail.  chrome console 'Uncaught Error: Cannot find module "islider"'.
It should islider.js but not islider.