### PR TITLE
添加resetAnimateType的原型函数

### DIFF
--- a/build/iSlider.js
+++ b/build/iSlider.js
@@ -1720,6 +1720,18 @@
         this._autoPlay();
         this.fire('reset slideRestored', this.slideIndex, this.currentEl, this);
     };
+    
+    /**
+     *  reset the animateType
+     *  
+     *  @param {string} animateType
+     *  @public
+     */
+    iSliderPrototype.resetAnimateType = function( animateType ) {
+        var self = this;
+        self._opts.animateType = self.animateType = animateType in self._animateFuncs ? animateType : 'normal';
+        self._animateFunc = self._animateFuncs[self.animateType];
+    };
 
     /**
      * Reload Data & render


### PR DESCRIPTION
我最近在使用iSlider.js来做一个单页的图片浏览的页面，我有两个视图，一个是提所有图片展示的视图，另一个是使用iSlider来展示的单个图片的视图。使用iSlider来展示的那个视图是随时在我的页面中隐藏的，只有用户在所有图片的展示视图点击了其中的某一个图片才会显示iSlider的这个视图。我想每一次用户重新点击某一张图片的时候都有不同的动画效果，但是我不想在得到新的滚动特效的时候都需要`destroy`和重新`new iSlider`，不过在官方文档中却没有相关的接口，所以我自己进行了一点儿小的修补，添加了这个resetAnimateType函数，希望能让这个优秀的JS库变得更好玩儿。