### PR TITLE
doc: fix a typo of slideNext in doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,7 @@ S.on('slideChanged', callBack);
     - \[`{Object}` temporary configuration\]
 
 
-#### slidePrev
+#### slideNext
 
 - Switch to the next scene, you can set the configuration information in second parameter to change slide animation this time: animateTime animateType
 - Parameters:

--- a/README_Chinese.md
+++ b/README_Chinese.md
@@ -619,7 +619,7 @@ S.on('slideChanged', callBack);
     - \[`{Object}` 临时配置\]
 
 
-#### slidePrev
+#### slideNext
 
 - 切换到后一场景，可以设置配置信息，改变本次滑动的动画效果: animateTime animateType
 - 参数：


### PR DESCRIPTION
文档中关于下一页的静态成员方法 `slideNext` 给了错误的名称，特此修复！